### PR TITLE
fix: 解析自定义类型错误

### DIFF
--- a/src/main/kotlin/cn/haloop/swi/openapi/visitor/SwiGoStructVisitor.kt
+++ b/src/main/kotlin/cn/haloop/swi/openapi/visitor/SwiGoStructVisitor.kt
@@ -97,7 +97,7 @@ class SwiGoStructVisitor : GoRecursiveVisitor() {
         } ?: run {
             metadata.fieldName = fieldDef.name.toString()
         }
-        metadata.fieldType = fieldDeclaration.type?.text ?: "Unknown Type"
+        metadata.fieldType = fieldDeclaration.type?.contextlessUnderlyingType?.text ?: "Unknown Type"
         metadata.fieldTitle =
             fieldDeclaration.tag?.getValue("desc") ?: fieldDeclaration.tag?.getValue("description") ?: ""
         metadata.fieldDesc = findFieldComment(fieldDef)


### PR DESCRIPTION
#3 解析自定义类型时，将fieldType解析为原始类型，例如：
```go 
type  Identifier string
```
那么解析到的类型应为`string`